### PR TITLE
Feature/cli interface

### DIFF
--- a/LoanShark.xcodeproj/project.pbxproj
+++ b/LoanShark.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		81239EDF226A68D700713960 /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81239EDE226A68D700713960 /* ArgumentParser.swift */; };
 		8149B7622216137300243E13 /* StatusTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149B7612216137300243E13 /* StatusTransformer.swift */; };
 		815CDAFF225529DF0020A0D7 /* String_Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815CDAFE225529DF0020A0D7 /* String_Extension.swift */; };
 		815E7FFC221CB11F009E3CA2 /* RemainingTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815E7FFB221CB11F009E3CA2 /* RemainingTransformer.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		81239EDE226A68D700713960 /* ArgumentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentParser.swift; sourceTree = "<group>"; };
 		8149B7612216137300243E13 /* StatusTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTransformer.swift; sourceTree = "<group>"; };
 		815CDAFE225529DF0020A0D7 /* String_Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String_Extension.swift; sourceTree = "<group>"; };
 		815E7FFB221CB11F009E3CA2 /* RemainingTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemainingTransformer.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				815E7FFB221CB11F009E3CA2 /* RemainingTransformer.swift */,
 				81CAD344220B2AC3003C5D32 /* ActivationAuthentication.swift */,
 				815CDAFE225529DF0020A0D7 /* String_Extension.swift */,
+				81239EDE226A68D700713960 /* ArgumentParser.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 				81CAD343220A3ED4003C5D32 /* TimerTransformer.swift in Sources */,
 				81CAD345220B2AC3003C5D32 /* ActivationAuthentication.swift in Sources */,
 				81CAD337220A1409003C5D32 /* NotificationName_Extension.swift in Sources */,
+				81239EDF226A68D700713960 /* ArgumentParser.swift in Sources */,
 				81CAD34D220B63DC003C5D32 /* ExtensionViewController.swift in Sources */,
 				81CAD335220A1379003C5D32 /* LoanPeriod.swift in Sources */,
 				81CAD32B220A0ABE003C5D32 /* Person.swift in Sources */,
@@ -577,7 +581,7 @@
 				CODE_SIGN_ENTITLEMENTS = LoanShark/LoanShark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 55JHL22EU7;
+				DEVELOPMENT_TEAM = Q6428T7Y4D;
 				INFOPLIST_FILE = LoanShark/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -597,7 +601,7 @@
 				CODE_SIGN_ENTITLEMENTS = LoanShark/LoanShark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 55JHL22EU7;
+				DEVELOPMENT_TEAM = Q6428T7Y4D;
 				INFOPLIST_FILE = LoanShark/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/LoanShark/AppDelegate.swift
+++ b/LoanShark/AppDelegate.swift
@@ -43,11 +43,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         
         Log.write(.debug, Log.Category.argumentParser, "Building argument parsing.")
         
+        //  Set Loan Period to Expired argument
         argParser.addArgument(name: "--set-expired", description: "Set loaner period to expired.", isBool: true) { (value) in
             Log.write(.info, Log.Category.application, "Set expiration argument sent, setting loaner period to expired.")
             self.loanerManager.setExpired()
         }
         
+        //  Perform extension argument
+        //  Requires --passcode parameter as well
         argParser.addArgument(name: "--extend", description: "Extend loaner by set number of days.") { (value) in
             Log.write(.info, Log.Category.application, "Loaner extension argument passed, attempting to extend loaner")
             
@@ -82,9 +85,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             }
         }
         
+        //  Authenticate using passcode
         argParser.addArgument(name: "--passcode", description: "Passcode to properly authenticate you") { (value) in
             
         }
+        
+        //  Get Loaner Status
+        argParser.addArgument(name: "--status", description: "Get the loaner period status", isBool: true) { (_) in
+            Log.write(.info, Log.Category.application, "Requested to provide loaner period status")
+            print(self.loanerManager.loanStatus.toString())
+            NSApp.terminate(self)
+        }
+        
+        //  Get Loanee Details
+        argParser.addArgument(name: "--loanee-details", description: "Get the loanee details", isBool: true) { (_) in
+            Log.write(.info, Log.Category.application, "Requested to give loanee details, getting and providing loanee information")
+            print(self.loanerManager.loanee?.description ?? "No Information to Provide")
+            NSApp.terminate(self)
+        }
+        
     }
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/LoanShark/AppDelegate.swift
+++ b/LoanShark/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         
         Log.write(.debug, Log.Category.argumentParser, "Building argument parsing.")
         
-        argParser.addArgument(name: "--set-expired", description: "Set loaner period to expired.") { (value) in
+        argParser.addArgument(name: "--set-expired", description: "Set loaner period to expired.", isBool: true) { (value) in
             Log.write(.info, Log.Category.application, "Set expiration argument sent, setting loaner period to expired.")
             self.loanerManager.setExpired()
         }
@@ -80,7 +80,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                 Log.write(.error, Log.Category.application, "Passcode provided is invalid")
                 NSApp.terminate(self)
             }
-            
         }
         
         argParser.addArgument(name: "--passcode", description: "Passcode to properly authenticate you") { (value) in

--- a/LoanShark/Tools/ArgumentParser.swift
+++ b/LoanShark/Tools/ArgumentParser.swift
@@ -6,15 +6,29 @@
 //  Copyright © 2019 Tyler Morgan. All rights reserved.
 //
 
-import Foundation
+import Cocoa
 
+/**
+ Errors thrown associated with the ArgumentParser class.
+ */
 enum ArgumentError: Error {
     case missingValue(String)
     case invalidType(value: String, type: String, argument: String? )
     case unsupportedArgument(String)
 }
 
+/**
+ Parses the arguments passed to the application and stores those values and settings.
+ */
 class ArgumentParser {
+    
+    
+    //  MARK: Structs
+    
+    /**
+     Elements an argument must have.
+     - Note: Apply is a function which gets called on when the argument is discovered.
+    */
     struct Argument {
         let name: String?
         let help: String?
@@ -22,15 +36,28 @@ class ArgumentParser {
         let isBool: Bool
     }
     
+    
+    //  MARK: Variables
+    
+    //  Arguments which are valid
     private var validOptions: [String] {
         return arguments.compactMap { $0.name }
     }
+    
     private var arguments: [Argument] = []
     
     private var argumentValues: [String:String] = [:]
     private var argumentCallbacks: [(_ values: [String:String]) throws -> ()] = []
     
+    
+    //  MARK: Functions
+    
+    /**
+     Parses the commndline arguments for the arguments requested.
+    */
     func parse() {
+        
+        //  Does CommandLine contain help command?
         if CommandLine.arguments.contains("--help") ||
             CommandLine.arguments.contains("-h")    ||
             CommandLine.arguments.contains("help") {
@@ -75,6 +102,15 @@ class ArgumentParser {
         }
     }
     
+    /**
+     Adds argument to a list to parse later.
+     
+     - Parameters:
+        - name: The parameter as String to monitor. Ex: `--title`
+        - description: A description or usage information of the argument
+        - isBool: Just monitor for the argument and set a true to false. *Default is false*
+        - callback: Function which you want to run when the argument is discovered. Function is provided a [String:String] element for parsing
+    */
     func addArgument(name: String, description help: String, isBool: Bool = false, callback: @escaping (_ value: [String:String]) throws -> ()) {
         let arg = Argument(name: name, help: help, apply: callback, isBool: isBool)
         self.arguments.append(arg)
@@ -84,6 +120,7 @@ class ArgumentParser {
         for arg in self.arguments {
             print("\(arg.name ?? "") - \(arg.help ?? "")")
         }
+        NSApp.terminate(self)
         exit(0)
     }
 }

--- a/LoanShark/Tools/ArgumentParser.swift
+++ b/LoanShark/Tools/ArgumentParser.swift
@@ -1,0 +1,79 @@
+//
+//  ArgumentParser.swift
+//  LoanShark
+//
+//  Created by Tyler Morgan on 4/19/19.
+//  Copyright © 2019 Tyler Morgan. All rights reserved.
+//
+
+import Foundation
+
+enum ArgumentError: Error {
+    case missingValue(String)
+    case invalidType(value: String, type: String, argument: String? )
+    case unsupportedArgument(String)
+}
+
+class ArgumentParser {
+    struct Argument {
+        let name: String?
+        let help: String?
+        let apply: (_ value: [String:String]) throws -> ()
+    }
+    
+    private var validOptions: [String] {
+        return arguments.compactMap { $0.name }
+    }
+    private var arguments: [Argument] = []
+    
+    private var argumentValues: [String:String] = [:]
+    private var argumentCallbacks: [(_ values: [String:String]) throws -> ()] = []
+    
+    func parse() {
+        if CommandLine.arguments.contains("--help") ||
+            CommandLine.arguments.contains("-h")    ||
+            CommandLine.arguments.contains("help") {
+            self.printUsage()
+        }
+        else {
+            for arg in CommandLine.arguments {
+                if validOptions.contains(arg) {
+                    let index = CommandLine.arguments.firstIndex(of: arg)
+                    let value = CommandLine.arguments[(index ?? 0) + 1]
+                    let elementIndex = self.validOptions.firstIndex(of: arg)
+                    
+                    let element = self.arguments[elementIndex ?? 0]
+                    self.argumentValues[arg] = value
+                    self.argumentCallbacks.append(element.apply)
+                }
+            }
+            
+            if self.argumentCallbacks.count > 0 {
+                for callback in self.argumentCallbacks {
+                    do {
+                        try callback(self.argumentValues)
+                    } catch ArgumentError.invalidType(let v, let t, let a) {
+                        Log.write(.fault, Log.Category.argumentParser, "Error occurred while converting \(v) into \(t) from argument \(String(describing: a)).")
+                    } catch ArgumentError.unsupportedArgument(let a) {
+                        Log.write(.fault, Log.Category.argumentParser, "Unsupported argument \(a) passed, add \"-h\" to read usage and requirements.")
+                    } catch ArgumentError.missingValue(let v) {
+                        Log.write(.fault, Log.Category.argumentParser, "Missing value for \(v)")
+                    } catch {
+                        Log.write(.fault, Log.Category.argumentParser, "Unknown error was thrown while parsing.")
+                    }
+                }
+            }
+        }
+    }
+    
+    func addArgument(name: String, description help: String, callback: @escaping (_ value: [String:String]) throws -> ()) {
+        let arg = Argument(name: name, help: help, apply: callback)
+        self.arguments.append(arg)
+    }
+    
+    private func printUsage() {
+        for arg in self.arguments {
+            print("\(arg.name ?? "") - \(arg.help ?? "")")
+        }
+    }
+}

--- a/LoanShark/Tools/ArgumentParser.swift
+++ b/LoanShark/Tools/ArgumentParser.swift
@@ -19,6 +19,7 @@ class ArgumentParser {
         let name: String?
         let help: String?
         let apply: (_ value: [String:String]) throws -> ()
+        let isBool: Bool
     }
     
     private var validOptions: [String] {
@@ -38,12 +39,20 @@ class ArgumentParser {
         else {
             for arg in CommandLine.arguments {
                 if validOptions.contains(arg) {
-                    let index = CommandLine.arguments.firstIndex(of: arg)
-                    let value = CommandLine.arguments[(index ?? 0) + 1]
-                    let elementIndex = self.validOptions.firstIndex(of: arg)
                     
+                    let index = CommandLine.arguments.firstIndex(of: arg)
+                    let elementIndex = self.validOptions.firstIndex(of: arg)
                     let element = self.arguments[elementIndex ?? 0]
-                    self.argumentValues[arg] = value
+                    
+                    if (self.arguments[elementIndex ?? 0]).isBool {
+                        let value = true
+                        self.argumentValues[arg] = String(describing: value)
+                    }
+                    else {
+                        let value = CommandLine.arguments[(index ?? 0) + 1]
+                        self.argumentValues[arg] = value
+                    }
+                    
                     self.argumentCallbacks.append(element.apply)
                 }
             }
@@ -66,8 +75,8 @@ class ArgumentParser {
         }
     }
     
-    func addArgument(name: String, description help: String, callback: @escaping (_ value: [String:String]) throws -> ()) {
-        let arg = Argument(name: name, help: help, apply: callback)
+    func addArgument(name: String, description help: String, isBool: Bool = false, callback: @escaping (_ value: [String:String]) throws -> ()) {
+        let arg = Argument(name: name, help: help, apply: callback, isBool: isBool)
         self.arguments.append(arg)
     }
     
@@ -75,5 +84,6 @@ class ArgumentParser {
         for arg in self.arguments {
             print("\(arg.name ?? "") - \(arg.help ?? "")")
         }
+        exit(0)
     }
 }

--- a/LoanShark/Tools/LoanManager.swift
+++ b/LoanShark/Tools/LoanManager.swift
@@ -287,4 +287,23 @@ import Foundation
             }
         }
     }
+    
+    /**
+     Set loaner period to expired.
+    */
+    func setExpired() {
+        
+        Log.write(.info, Log.Category.loanManager, "Setting loaner period to expired.")
+        
+        DispatchQueue.global(qos: .background).async {
+            let currDate = Date()
+            let newDate = Calendar.current.date(byAdding: .day, value: -30, to: currDate)
+            
+            Preferences.sharedInstance.endDate = newDate
+            
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: NSNotification.Name.loanerPeriodExpired, object: nil)
+            }
+        }
+    }
 }

--- a/LoanShark/Tools/Log.swift
+++ b/LoanShark/Tools/Log.swift
@@ -20,6 +20,7 @@ class Log {
         static let loanManager = "LoanManager"
         static let statusListener = "StatusListener"
         static let authenticator = "Authenticator"
+        static let argumentParser = "ArgumentParser"
     }
     
     

--- a/LoanShark/Tools/Preferences.swift
+++ b/LoanShark/Tools/Preferences.swift
@@ -149,6 +149,12 @@ class Preferences {
         }
     }
     
+    public var sharedSecretAuth: Bool {
+        get {
+            return self.userDefaults.bool(forKey: "sharedSecretAuth")
+        }
+    }
+    
     public var jamfCloud: Bool {
         get {
             return self.userDefaults.bool(forKey: "jamfCloud")

--- a/LoanShark/Views/AuthenticationViewController.swift
+++ b/LoanShark/Views/AuthenticationViewController.swift
@@ -49,6 +49,10 @@ class AuthenticationViewController: NSViewController {
         guard let _ = Preferences.sharedInstance.sharedSecret else {
             return false
         }
+        
+        if !Preferences.sharedInstance.sharedSecretAuth {
+            return false
+        }
         return true
     }
     


### PR DESCRIPTION
Added CLI argument parsing.

Included the following commands

| Command | Description | Example |
| ---------- | ------------ | ---------- |
| `--set-expired` | Sets the loaning period to expired. | `LoanShark.app/Contents/MacOS/LoanShark --set-expired`|
| `--passcode` | Used to provide the shared secret on the CLI level to authenticate to extend the loaning period | `LoanShark.app/Contents/MacOS/LoanShark --passcode "Monkey123" --extend 10` |
| `--extend` | Extends the loaning period by the specified days. This includes negative numbers. *Requires `passcode`* as well to perform authentication | `LoanShark.app/Contents/MacOS/LoanShark --extend 10 --passcode Monkey123` |
| `--status` | Gives you the status of the loaner | `LoanShark.app/Contents/MacOS/LoanShark --status` |
| `--loanee-details` | Provides loanee details of the currently assigned loaning period | `LoanShark.app/Contents/MacOS/LoanShark --loanee-details` |